### PR TITLE
Implement Simple Dispatcher

### DIFF
--- a/Dispatcher.cs
+++ b/Dispatcher.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UnityWrap
+{
+    public class Dispatcher
+    {
+        private readonly IDictionary<DispatcherTiming, ConcurrentQueue<Action>> _queues =
+            new Dictionary<DispatcherTiming, ConcurrentQueue<Action>>
+            {
+                {DispatcherTiming.Update, new ConcurrentQueue<Action>()},
+                {DispatcherTiming.FixedUpdate, new ConcurrentQueue<Action>()},
+                {DispatcherTiming.LateUpdate, new ConcurrentQueue<Action>()},
+            };
+
+        public void Invoke(Action action, DispatcherTiming timing = DispatcherTiming.Update)
+        {
+            _queues[timing].Enqueue(action);
+        }
+
+        internal void DoWork(DispatcherTiming timing)
+        {
+            var work = GetWork(timing).ToList();
+            foreach (var action in work)
+            {
+                action();
+            }
+        }
+
+        private IEnumerable<Action> GetWork(DispatcherTiming timing)
+        {
+            var queue = _queues[timing];
+
+            while (!queue.IsEmpty)
+            {
+                if (queue.TryDequeue(out var action))
+                    yield return action;
+                else
+                    break;
+            }
+        }
+    }
+}

--- a/DispatcherBehavior.cs
+++ b/DispatcherBehavior.cs
@@ -1,0 +1,25 @@
+﻿namespace UnityWrap
+{
+    public class DispatcherBehavior : Behavior
+    {
+        public Dispatcher Dispatcher { get; } = new Dispatcher();
+
+        protected override void Update()
+        {
+            Dispatcher.DoWork(DispatcherTiming.Update);
+            base.Update();
+        }
+
+        protected override void FixedUpdate()
+        {
+            Dispatcher.DoWork(DispatcherTiming.FixedUpdate);
+            base.FixedUpdate();
+        }
+
+        protected override void LateUpdate()
+        {
+            Dispatcher.DoWork(DispatcherTiming.LateUpdate);
+            base.LateUpdate();
+        }
+    }
+}

--- a/DispatcherTiming.cs
+++ b/DispatcherTiming.cs
@@ -1,0 +1,9 @@
+﻿namespace UnityWrap
+{
+    public enum DispatcherTiming
+    {
+        Update,
+        FixedUpdate,
+        LateUpdate
+    }
+}

--- a/UnityWrap.csproj
+++ b/UnityWrap.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Unity API Wrapper</Description>
     <RepositoryUrl>https://github.com/EnsignPayton/UnityWrap</RepositoryUrl>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <Authors>DragonStallion</Authors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>


### PR DESCRIPTION
Use `DispatcherBehavior` when you need to access the render thread from
a background thread. Wrap all the render code in a `Dispatcher.Invoke`
and it will run on the next *`Update`.

Could technically be used from the render thread, but it's significantly
less useful in that case.